### PR TITLE
Add C API to return Public Suffix List

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,9 @@ jobs:
       - name: Run unit tests
         env:
           CARGO_TERM_COLOR: always
+        run: cargo test
+
+      - name: Run unit tests (with PSL)
+        env:
+          CARGO_TERM_COLOR: always
         run: cargo test --features real-psl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "url_predictor"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/cbindgen_no_psl.toml
+++ b/cbindgen_no_psl.toml
@@ -7,3 +7,6 @@ header = """
 """
 include_version = true
 braces = "NextLine"
+
+[export]
+exclude = [ "ddg_up_get_psl_data" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,15 @@ pub extern "C" fn ddg_up_free_string(ptr: *mut c_char) {
     unsafe { let _ = CString::from_raw(ptr); }
 }
 
+#[cfg(feature = "real-psl")]
+#[unsafe(no_mangle)]
+pub extern "C" fn ddg_up_get_psl_data() -> *mut c_char {
+    // Return the vendored Public Suffix List contents as a C string.
+    // Caller must free with `ddg_up_free_string`.
+    const PSL: &str = include_str!("../assets/public_suffix_list.dat");
+    CString::new(PSL).unwrap().into_raw()
+}
+
 // -----------------------------------------------------------------------------
 // JNI (Android only)
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211450429415880?focus=true

This change adds a new C function that returns Public Suffix List contents, gated behind the real-psl feature.