### PR TITLE
Fix embedded newline/tab misclassified as Navigate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ android/ddg-url-predictor/src/main/jniLibs/
 android/ddg-url-predictor/src/test/resources/
 
 # =========================
+# Claude Code
+# =========================
+.claude/
+
+# =========================
 # Misc / OS
 # =========================
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+cargo build                          # default build (uses DemoSuffixDb)
+cargo build --features real-psl      # build with real Public Suffix List
+cargo test                           # run all tests
+cargo test --features real-psl       # run tests with real PSL
+cargo test <test_name>               # run a single test by name
+```
+
+Android unit tests:
+```sh
+cargo build --release --features "real-psl jni-host-tests"
+cd android && ./gradlew :ddg-url-predictor:testDebugUnitTest
+```
+
+## Architecture
+
+Everything lives in `src/lib.rs` (intentionally single-module). The entry points are:
+
+- `classify(input, policy)` — public Rust API, uses the global `DEFAULT_SUFFIX_DB`
+- `classify_with_db(input, policy, db)` — same but accepts an explicit `SuffixDb` (used in tests)
+- `ddg_up_classify_json(input_ptr, policy_ptr)` — C FFI wrapper, returns heap-allocated JSON string; caller must free with `ddg_up_free_string`
+
+### Classification flow (`classify_with_db`)
+
+1. **Reject embedded newlines/tabs** → `Search` (security fix: url crate silently strips these, which would misclassify `https://bbc.com\nfoo` as Navigate)
+2. **Absolute URL with known scheme** → `Navigate`
+3. **Absolute URL with unknown scheme** → `Search` with `unknown_scheme_navigation` populated
+4. **Scheme-relative `//host`** → `Navigate`
+5. **File paths** (if `policy.allow_file_paths`) → `Navigate`
+6. **Multi-word input** → `Search`
+7. **Host-like classification** → checks IPs, localhost, IDNA hostnames, PSL lookup, intranet rules
+
+### Key types
+
+- `Decision` — `Navigate { url }` or `Search { query, unknown_scheme_navigation? }`
+- `Policy` — controls intranet, private suffixes, allowed schemes, file paths
+- `SuffixDb` trait — abstraction over PSL backends
+  - `DemoSuffixDb` — tiny hardcoded set for tests/default builds
+  - `RealSuffixDb` — full PSL via `publicsuffix` crate (feature `real-psl`), reads from `assets/public_suffix_list.dat`
+
+### Generated code
+
+`src/generated_suffix_allowlist.rs` contains `ALWAYS_NAVIGATE_SUFFIX_ROOTS` — a sorted array of suffix roots (e.g. `blogspot.com`) that should always be treated as Navigate even though they're public suffixes. Regenerate it with:
+
+```sh
+python tools/generate_suffix_root_allowlist.py \
+  --psl assets/public_suffix_list.dat \
+  --rust-out src/generated_suffix_allowlist.rs \
+  --json-out data/suffix_root_allowlist.json \
+  --debug-out data/suffix_root_debug.json
+```
+
+This script probes the network, so it's slow. Run it only after updating `assets/public_suffix_list.dat` via `./scripts/update_psl.sh`.
+
+### PSL FFI
+
+When built with `real-psl`, the library also exposes `ddg_up_get_psl_ptr()` / `ddg_up_get_psl_len()` for zero-copy access to the embedded PSL data from native callers (iOS/Windows). Do NOT free that pointer.
+
+### Platform builds
+
+Scripts under `scripts/` cross-compile for Android (`.so`), iOS/macOS (`.a`/`.dylib`), and Windows (`.dll`). Output goes to `dist/` (not checked in).
+
+### Features
+
+- `real-psl` — enables `RealSuffixDb` backed by the full Public Suffix List
+- `jni-host-tests` — enables JNI bindings for running Android tests on the host JVM
+
+## Releasing (Android)
+
+See `android/RELEASING.md` or use `android/release_android.sh`. Always do a dry run first:
+
+```sh
+cd android && ./release_android.sh --new-version X.Y.Z --dry-run
+```
+
+The `.so` binaries in `android/ddg-url-predictor/src/main/jniLibs` are checked in and must be rebuilt via `scripts/build_android.sh` and committed before releasing if there are any Rust changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,13 @@ pub fn classify_with_db(input: &str, policy: &Policy, db: &dyn SuffixDb) -> Deci
         return Decision::Search { query: String::new(), unknown_scheme_navigation: None };
     }
 
+    // Embedded newlines/tabs are silently stripped by the `url` crate during parsing,
+    // which can cause inputs like "https://bbc.com\ntest" to be misclassified as Navigate.
+    // Reject them as Search before reaching the URL parser.
+    if original.contains('\n') || original.contains('\r') || original.contains('\t') {
+        return Decision::Search { query: original.to_string(), unknown_scheme_navigation: None };
+    }
+
     // Check for absolute URL - track unknown schema for possible use at end
     let unknown_scheme_navigation = match parse_absolute_url(original, policy) {
         AbsoluteUrlResult::Allowed(url) => return Decision::Navigate { url },
@@ -828,7 +835,11 @@ mod tests {
         assert!(matches!(classify("https://duckduckgo.com/?q=search+string+with+spaces", &p), Decision::Navigate { url } if url == "https://duckduckgo.com/?q=search+string+with+spaces"));
         assert!(matches!(classify("https://screwjankgames.github.io/engine programming/2020/09/24/writing-your.html", &p), Decision::Navigate { url } if url == "https://screwjankgames.github.io/engine%20programming/2020/09/24/writing-your.html"));
         assert!(matches!(classify("define: foo", &p), Decision::Search { query, unknown_scheme_navigation: None } if query == "define: foo"));
-        assert!(matches!(classify("   http://example.com\n", &p), Decision::Navigate { url } if url == "http://example.com/"));
+        assert!(matches!(classify("   http://example.com\n", &p), Decision::Navigate { url } if url == "http://example.com/")); // trailing newline stripped by trim → Navigate
+        assert!(matches!(classify("https://bbc.com\ntest", &p), Decision::Search { .. })); // embedded newline → Search
+        assert!(matches!(classify("bbc.com\ntest", &p), Decision::Search { .. })); // embedded newline, no scheme → Search
+        assert!(matches!(classify("https://bbc.com\rtest", &p), Decision::Search { .. })); // embedded CR → Search
+        assert!(matches!(classify("https://bbc.com\ttest", &p), Decision::Search { .. })); // embedded tab → Search
         assert!(matches!(classify(" duckduckgo.com", &p), Decision::Navigate { url } if url == "http://duckduckgo.com/"));
         assert!(matches!(classify(" duck duck go.c ", &p), Decision::Search { query, unknown_scheme_navigation: None } if query == "duck duck go.c"));
         assert!(matches!(classify("localhost ", &p), Decision::Navigate { url } if url == "http://localhost/"));


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213556221780433/task/1213557156293985?focus=true

### Description

The `url` crate silently strips embedded newlines (`\n`, `\r`) and tabs (`\t`) during URL parsing. This caused inputs like `https://bbc.com\nmalicious.com` to be misclassified as **Navigate** instead of **Search**.

Fix: reject any input containing these characters early in `classify_with_db`, before reaching the URL parser.

### Steps to test this PR

- [ ] `cargo test` passes
- [ ] `cargo test --features real-psl` passes
- [ ] Input `https://bbc.com\ntest` returns `Search`, not `Navigate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core URL-vs-search classification by rejecting inputs containing embedded control characters before URL parsing, which could affect edge-case navigation behavior across platforms. Scope is small and covered by new tests, but it touches a security-sensitive decision point.
> 
> **Overview**
> Prevents URL injection-style inputs (e.g. `https://bbc.com\ntest`) from being misclassified as **Navigate** by returning **Search** early when the trimmed input contains embedded `\n`, `\r`, or `\t`.
> 
> Adds regression tests for the new behavior (while keeping trailing-newline-after-`trim` behavior unchanged), and includes small repo hygiene updates: ignore `.claude/` and add `CLAUDE.md` with contributor/Claude Code guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc1904ca980027c55a3fe09cda0f522baab1586f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->