### PR TITLE
Static VCLibs for Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Statically link the MSVC C runtime so the produced *.dll files do not depend on
+# vcruntime140.dll (delivered via the Microsoft.VCLibs framework package on Windows).
+# Scoped to MSVC targets only, so Android (*-linux-android) and Apple (*-apple-*)
+# cross-builds are unaffected.
+[target.'cfg(target_env = "msvc")']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Static vclibs for Windows

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
    3. Make sure these changes are tested in API 23 and API 26
If your PR does not involve UI changes, you can remove the **UI changes** section
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210132634900450/task/1213969107184482?focus=true

### Description
Include vclibs statically for Windows

### Steps to test this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-time linker behavior changes for all Windows MSVC artifacts; wrong scoping or CRT mismatch could affect binary size, compatibility, or runtime behavior on Windows targets only.
> 
> **Overview**
> Windows **MSVC** builds now set **`+crt-static`** via a new **`.cargo/config.toml`**, so produced **`*.dll`** files no longer depend on **`vcruntime140.dll`** (the runtime normally pulled in through the **Microsoft.VCLibs** framework package).
> 
> The **`rustflags`** apply only when **`target_env = "msvc"`**, so **Android** and **Apple** cross-compiles are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 423ea7ed4b95a05db75cdd57a726bedb0ec8b7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->